### PR TITLE
Add missing ending quote marks

### DIFF
--- a/archive/blogs/2015-07-02-cronntab-rbenv-bundle-exec-rake-task.md
+++ b/archive/blogs/2015-07-02-cronntab-rbenv-bundle-exec-rake-task.md
@@ -33,7 +33,7 @@ crontab -u deploy -e
 And we add:
 
 ```bash
-* * * * * PATH=$PATH:/usr/local/bin && bash -lc "cd /home/deploy/apps/myapp && RACK_ENV=production bundle exec rake event:process
+* * * * * PATH=$PATH:/usr/local/bin && bash -lc "cd /home/deploy/apps/myapp && RACK_ENV=production bundle exec rake" event:process
 ```
 
 Obviously the  `* * * * *` is a crontab scheduling syntax (run something every minute) and you can learn
@@ -92,7 +92,7 @@ tail -f /var/log/syslog
 For me helpfull was to add something like this to crontab:
 
 ```bash
-* * * * * PATH=$PATH:/usr/local/bin && bash -lc "cd /home/deploy/apps/myapp && RACK_ENV=production bundle exec rake event:process > /tmp/lets_figure_this_out.txt
+* * * * * PATH=$PATH:/usr/local/bin && bash -lc "cd /home/deploy/apps/myapp && RACK_ENV=production bundle exec rake event:process > /tmp/lets_figure_this_out.txt"
 ```
 
 To check what ENV variables are actually set:


### PR DESCRIPTION
Good article, it helped me set-up cron to run a nightly ruby gem via rbenv - so thank you for that.

I think there's an error with the cron command lines, however, as you don't seem to have ending quote marks for them, which I assume are probably required.