### PR TITLE
Fix typo in 'Separate Validation Object' section

### DIFF
--- a/archive/blogs/2016-02-28-rails-validators-in-separte-object.md
+++ b/archive/blogs/2016-02-28-rails-validators-in-separte-object.md
@@ -454,7 +454,7 @@ end
 class IdentityUpdater
   include ActiveModel::Validations
 
-  attr_accessor :submitted_identity, :identity_id
+  attr_accessor :submitted_email, :identity_id
 
   validates_presence_of :submitted_email
   validates_format_of   :submitted_email, with: EMAIL_REXP
@@ -492,7 +492,7 @@ end
 # app/controllers/identities_controller.rb
 class IdentitiesController
   def update
-    @service = OauthIdentityCreator.new.tap do |service|
+    @service = IdentityUpdater.new.tap do |service|
       service.submitted_email = params[:auth][:submitted_email]
       service.identity_id     = params[:id]
     end


### PR DESCRIPTION
Fix 2 typos in the code example of 'Separate Validation Object'.  I think they are typos, but if not, please disregard.
